### PR TITLE
Accept the same initialize args as Koala

### DIFF
--- a/lib/instagram_graph_api/client.rb
+++ b/lib/instagram_graph_api/client.rb
@@ -8,8 +8,5 @@ module InstagramGraphApi
     include InstagramGraphApi::Client::Media
     include InstagramGraphApi::Client::Discovery
 
-    def initialize(media_id = nil, access_token)
-      super(access_token)
-    end
   end
 end


### PR DESCRIPTION
Our app uses both an access token and our applicatino secret to support signed requests to the
Facebook API. This PR updates the client to accept the same arguments for initialization as the
Koala gem so we can get the signed requests.