### PR TITLE
Add support dual insights method, that endpoints of ig_media_id and ig_user_id.

### DIFF
--- a/lib/instagram_graph_api/client.rb
+++ b/lib/instagram_graph_api/client.rb
@@ -4,6 +4,7 @@ module InstagramGraphApi
   class Client < Koala::Facebook::API
     Dir[File.expand_path('../client/*.rb', __FILE__)].each{|f| require f}
 
+    include InstagramGraphApi::Client::Insights
     include InstagramGraphApi::Client::Users
     include InstagramGraphApi::Client::Media
     include InstagramGraphApi::Client::Discovery

--- a/lib/instagram_graph_api/client/insights.rb
+++ b/lib/instagram_graph_api/client/insights.rb
@@ -1,0 +1,14 @@
+module InstagramGraphApi
+  class Client
+    module Insights
+      def insights(object_id, metrics: nil)
+        metrics ||= METRIC_HASH[type.to_sym]
+        @raw_insights = get_connections(object_id, "insights?metric=#{metrics}")
+        @raw_insights.reduce({}) do |result, insight_data|
+          result[insight_data["name"]] = insight_data["values"].first["value"]
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/instagram_graph_api/client/insights.rb
+++ b/lib/instagram_graph_api/client/insights.rb
@@ -1,7 +1,14 @@
 module InstagramGraphApi
   class Client
     module Insights
-      def insights(object_id, metrics: nil)
+
+      METRIC_HASH = {
+        image: 'impressions,reach',
+        video: 'impressions,reach,video_views',
+        story: 'impressions,replies,reach,taps_forward,taps_back,exits'
+      }
+
+      def insights(object_id, type: "image", metrics: nil)
         metrics ||= METRIC_HASH[type.to_sym]
         @raw_insights = get_connections(object_id, "insights?metric=#{metrics}")
         @raw_insights.reduce({}) do |result, insight_data|

--- a/lib/instagram_graph_api/client/media.rb
+++ b/lib/instagram_graph_api/client/media.rb
@@ -32,14 +32,6 @@ module InstagramGraphApi
         get_connections(media_id , "?fields=#{fields}")
       end
 
-      def insights(media_id, type: "image", metrics: nil)
-        metrics ||= METRIC_HASH[type.to_sym]
-        @raw_insights = get_connections(media_id , "insights?metric=#{metrics}")
-        @raw_insights.reduce({}) do |result, insight_data|
-          result[insight_data["name"]] = insight_data["values"].first["value"]
-          result
-        end
-      end
     end
   end
 end

--- a/lib/instagram_graph_api/client/media.rb
+++ b/lib/instagram_graph_api/client/media.rb
@@ -3,12 +3,6 @@ module InstagramGraphApi
     module Media
       attr_accessor :media_info, :raw_insights
 
-      METRIC_HASH = {
-        image: 'impressions,reach',
-        video: 'impressions,reach,video_views',
-        story: 'impressions,replies,reach,taps_forward,taps_back,exits'
-      }
-
       MEDIA_INFO_HASH = {
         image: "comments_count,like_count,media_type,"\
                     "media_url,permalink,timestamp,thumbnail_url",

--- a/lib/instagram_graph_api/version.rb
+++ b/lib/instagram_graph_api/version.rb
@@ -1,3 +1,3 @@
 module InstagramGraphApi
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end


### PR DESCRIPTION
https://developers.facebook.com/docs/instagram-api/guides/insights

Also, 

```
Endpoints
The API consists of the following endpoints:

GET /{ig-media-id}/insights — gets metrics on a media object
GET /{ig-user-id}/insights — gets metrics on an Instagram Business Account or Instagram Creator account.
Refer to each endpoint's reference documentation for available metrics, parameters, and permission requirements.
```

This commit supported both endpoints.

Please review.

Regards.
